### PR TITLE
Update deps so polymer 1.1.0 gets pulled in

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "license": "http://polymer.github.io/LICENSE.txt",
   "private": true,
   "dependencies": {
-    "platinum-sw": "PolymerElements/platinum-sw#~1.2.0",
-    "platinum-push-messaging": "PolymerElements/platinum-push-messaging#~1.0.0"
+    "platinum-sw": "PolymerElements/platinum-sw#^1.2.0",
+    "platinum-push-messaging": "PolymerElements/platinum-push-messaging#^1.0.0"
   }
 }


### PR DESCRIPTION
`^` is more relaxed and follows the rest of the element sets

@jeffposnick @wibblymat 